### PR TITLE
Fixed bug where toolbar icon didn't visually show unlocked science.

### DIFF
--- a/BeaverBuddies/Events/ToolEvents.cs
+++ b/BeaverBuddies/Events/ToolEvents.cs
@@ -12,6 +12,7 @@ using Timberborn.EntitySystem;
 using Timberborn.Forestry;
 using Timberborn.PlantingUI;
 using Timberborn.ScienceSystem;
+using Timberborn.SingletonSystem;
 using Timberborn.ToolSystem;
 using Timberborn.WorkSystemUI;
 using UnityEngine;
@@ -328,9 +329,8 @@ namespace BeaverBuddies.Events
                 if (toolBuilding == building)
                 {
                     Plugin.Log("Unlocking tool for building: " + buildingName);
-                    // TODO: Need to test - I think this is equivalent to clearing the lock
-                    // but not sure it'll update the UI
                     blockObjectTool.Locker = null;
+                    toolButton.OnToolUnlocked(new ToolUnlockedEvent(tool));
                 }
             }
         }


### PR DESCRIPTION
I took a look at why science wasn't updating the toolbar when another player unlocked it.

I tried two solutions to fix this. The first:
`context.GetSingleton<EventBus>().Post(new ToolUnlockedEvent(tool));`
Was sending an event on the bus. This seemed to work, but I don't know much about the game so I didn't know whether this mod was trying to avoid using the event bus for some reason.

The second solution was to inline a call to the OnToolUnlocked listener in the ToolButton class. This would normally run when an event is sent out on the bus, but like I said I'm not 100% sure what I'm doing.

Is this a good way to fix this? Or should an event be sent out on the bus? Or something else?