### PR TITLE
#60 - Fix Version format - GetConfigPath

### DIFF
--- a/BeaverBuddies/ConfigIOService.cs
+++ b/BeaverBuddies/ConfigIOService.cs
@@ -63,7 +63,7 @@ namespace BeaverBuddies
         {
             if (configPath != null) return configPath;
 
-            var mod = _modRepository.Mods.Where(mod => mod.Manifest.Id == Plugin.ID).FirstOrDefault();
+            var mod = _modRepository.Mods.Where(mod => mod.Manifest.Id == Plugin.ID && mod.Manifest.Version.Full == Plugin.Version && ModdedState.IsModded && mod.IsEnabled).FirstOrDefault();
             if (mod == null)
             {
                 Plugin.LogWarning("Cannot find mod from repository!");

--- a/BeaverBuddies/Plugin.cs
+++ b/BeaverBuddies/Plugin.cs
@@ -104,7 +104,7 @@ namespace BeaverBuddies
     [HarmonyPatch]
     public class Plugin : IModStarter
     {
-        public static readonly string Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        public static readonly string Version = Assembly.GetExecutingAssembly().GetName().Version.Major + "." + Assembly.GetExecutingAssembly().GetName().Version.Minor + "." + Assembly.GetExecutingAssembly().GetName().Version.MajorRevision;
         public const string Name = "BeaverBuddies";
         public const string ID = "beaverbuddies";
 


### PR DESCRIPTION
Fix for [GetConfigPath](https://github.com/thomaswp/BeaverBuddies/issues/60)

Note: GetConfigPath requires a version in the x.x.x format when using the "Where" function inside.