### PR TITLE
Update to be compatible with 2025-09-17 version

### DIFF
--- a/BeaverBuddies/DesyncDetecter/DesyncPatches.cs
+++ b/BeaverBuddies/DesyncDetecter/DesyncPatches.cs
@@ -209,10 +209,10 @@ namespace BeaverBuddies.DesyncDetecter
     //    }
     //}
 
-    [HarmonyPatch(typeof(SoilMoistureMap), nameof(SoilMoistureMap.UpdateMoistureLevels))]
+    [HarmonyPatch(typeof(SoilMoistureService), nameof(SoilMoistureService.UpdateMoistureLevels))]
     public class SoilMoistureMapSetMoistureLevelPatcher
     {
-        public static void Postfix(SoilMoistureMap __instance)
+        public static void Postfix(SoilMoistureService __instance)
         {
             if (!Settings.Debug) return;
             // During saves, this gets called early, but it just syncs the
@@ -224,7 +224,7 @@ namespace BeaverBuddies.DesyncDetecter
             // Just always update the moisture levels at the end of the tick.
             if (GameSaverSavePatcher.IsSaving) return;
 
-            var levels = __instance._soilMoistureSimulator._moistureLevels;
+            var levels = __instance._soilMoistureSimulator.MoistureLevels;
             int hash = 13;
             foreach (var level in levels)
             {
@@ -234,14 +234,14 @@ namespace BeaverBuddies.DesyncDetecter
         }
     }
 
-    [HarmonyPatch(typeof(ThreadSafeWaterMap), nameof(ThreadSafeWaterMap.UpdateData))]
+    [HarmonyPatch(typeof(ThreadSafeWaterMap), nameof(ThreadSafeWaterMap.Update))]
     public class ThreadSafeWaterMapUpdateDataPatcher
     {
         public static void Postfix(ThreadSafeWaterMap __instance)
         {
             if (!Settings.Debug) return;
 
-            var columns = __instance._waterColumns;
+            var columns = __instance._threadSafeWaterColumns;
             int hash = 13;
             foreach (var level in columns)
             {
@@ -250,7 +250,7 @@ namespace BeaverBuddies.DesyncDetecter
             DesyncDetecterService.Trace($"Updating water map columns with hash {hash:X8}");
             
             hash = 13;
-            var counts = __instance._columnCounts;
+            var counts = __instance._threadSafeColumnCounts;
             foreach (byte count in counts)
             {
                 hash = (hash * 7) + count;

--- a/BeaverBuddies/Fixes/TickOnlyArrayFix.cs
+++ b/BeaverBuddies/Fixes/TickOnlyArrayFix.cs
@@ -1,0 +1,29 @@
+using HarmonyLib;
+using System;
+using System.Reflection;
+using Timberborn.TickSystem;
+
+namespace BeaverBuddies.Fixes
+{
+    /// <summary>
+    /// Fix for TickOnlyArray crash during saves.
+    /// Patches TickOnlyArrayService.AllowEdit to return true during save operations.
+    /// </summary>
+    [HarmonyPatch(typeof(TickOnlyArrayService), nameof(TickOnlyArrayService.AllowEdit), MethodType.Getter)]
+    class TickOnlyArrayServiceAllowEditPatch
+    {
+        static bool Prefix(ref bool __result)
+        {
+            // Allow edit access during save operations since saves only need read access
+            // but the poorly designed API requires write permission for read operations
+            if (GameSaveHelper.IsSavingDeterministically || GameSaverSavePatcher.IsSaving)
+            {
+                __result = true;
+                return false; // Skip original method
+            }
+
+            // Fall back to original method for normal operations
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixed two crashes:

# Crash at opening
Stack:
```
TypeLoadException: Could not load type Timberborn.SoilMoistureSystem.SoilMoistureMap, Timberborn.SoilMoistureSystem, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null while decoding custom attribute: (null)
System.MonoCustomAttrs.GetCustomAttributesBase (System.Reflection.ICustomAttributeProvider obj, System.Type attributeType, System.Boolean inheritedOnly) (at <4780199c95764436ade50bbd58f63488>:0)
System.MonoCustomAttrs.GetCustomAttributes (System.Reflection.ICustomAttributeProvider obj, System.Type attributeType, System.Boolean inherit) (at <4780199c95764436ade50bbd58f63488>:0)
System.RuntimeType.GetCustomAttributes (System.Boolean inherit) (at <4780199c95764436ade50bbd58f63488>:0)
HarmonyLib.HarmonyMethodExtensions.GetFromType (System.Type type) (at <474744d65d8e460fa08cd5fd82b5d65f>:0)
HarmonyLib.PatchClassProcessor..ctor (HarmonyLib.Harmony instance, System.Type type, System.Boolean allowUnannotatedType) (at <474744d65d8e460fa08cd5fd82b5d65f>:0)
HarmonyLib.PatchClassProcessor..ctor (HarmonyLib.Harmony instance, System.Type type) (at <474744d65d8e460fa08cd5fd82b5d65f>:0)
HarmonyLib.Harmony.CreateClassProcessor (System.Type type) (at <474744d65d8e460fa08cd5fd82b5d65f>:0)
HarmonyLib.Harmony.<PatchAll>b__11_0 (System.Type type) (at <474744d65d8e460fa08cd5fd82b5d65f>:0)
HarmonyLib.CollectionExtensions.Do[T] (System.Collections.Generic.IEnumerable`1[T] sequence, System.Action`1[T] action) (at <474744d65d8e460fa08cd5fd82b5d65f>:0)
HarmonyLib.Harmony.PatchAll (System.Reflection.Assembly assembly) (at <474744d65d8e460fa08cd5fd82b5d65f>:0)
HarmonyLib.Harmony.PatchAll () (at <474744d65d8e460fa08cd5fd82b5d65f>:0)
BeaverBuddies.Plugin.StartMod () (at <f11fe12212254870a281d4bd5b813371>:0)
```

Solution: rename.


# Crash during save
Stack:
```
InvalidOperationException: Cannot access array outside of singleton Tick.
Timberborn.TickSystem.TickOnlyArray`1[T].GetSpan () (at <a930e7d5dfde40189a4be4b637a4451d>:0)
Timberborn.TickSystem.TickOnlyArray`1[T].GetReadOnlySpan () (at <a930e7d5dfde40189a4be4b637a4451d>:0)
Timberborn.WaterSystem.WaterSimulator.Save (Timberborn.WorldPersistence.ISingletonSaver singletonSaver) (at <cbffed59c3114e4281b7924ab414102e>:0)
Timberborn.WorldPersistence.SerializedWorldFactory.SaveSingletons (Timberborn.WorldSerialization.SerializedWorld serializedWorld, System.Collections.Generic.IEnumerable`1[T] singletons) (at <e769572ceb3c4c6dbad4c99ac21ed3bb>:0)
Timberborn.WorldPersistence.SerializedWorldFactory.SaveSingletons (Timberborn.WorldSerialization.SerializedWorld serializedWorld) (at <e769572ceb3c4c6dbad4c99ac21ed3bb>:0)
Timberborn.WorldPersistence.SerializedWorldFactory.Create () (at <e769572ceb3c4c6dbad4c99ac21ed3bb>:0)
Timberborn.WorldPersistence.WorldEntryWriter.WriteToSaveEntryStream (System.IO.Stream entryStream) (at <e769572ceb3c4c6dbad4c99ac21ed3bb>:0)
Timberborn.SaveSystem.SaveWriter.WriteToSaveStream (System.IO.Stream saveStream, System.Boolean leaveOpen) (at <0f4090009f3843a8842ac9111f451aa2>:0)
Timberborn.GameSaveRuntimeSystem.GameSaver.Save (Timberborn.GameSaveRuntimeSystem.GameSaver+QueuedSave queuedSave) (at <04fbdefe5e6f4088a6889c7061ea98cd>:0)
Timberborn.GameSaveRuntimeSystem.GameSaver.SaveQueued () (at <04fbdefe5e6f4088a6889c7061ea98cd>:0)
Timberborn.GameSaveRuntimeSystem.GameSaverUnityAdapter.LateUpdate () (at <04fbdefe5e6f4088a6889c7061ea98cd>:0)
```

Solution: Patches TickOnlyArrayService.AllowEdit to return true during save operations.

